### PR TITLE
Generate a minified version of the JS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,14 +1,26 @@
 module.exports = function(grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
+
         concat: {
             dist: {
                 src: ['src/**/*.js'],
                 dest: 'dist/gameboy.js'
             }
+        },
+
+        uglify: {
+            dist: {
+                files: {
+                    "dist/gameboy.min.js": ["dist/gameboy.js"]
+                }
+            }
         }
+
     });
 
     grunt.loadNpmTasks('grunt-contrib-concat');
-    grunt.registerTask('default', ['concat']);
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+
+    grunt.registerTask('default', ['concat', 'uglify']);
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "devDependencies": {
         "grunt": "~0.4.5",
         "grunt-cli": "~0.1.13",
-        "grunt-contrib-concat": "~0.5.1"
+        "grunt-contrib-concat": "~0.5.1",
+        "grunt-contrib-uglify": "^4.0.1"
     }
 }


### PR DESCRIPTION
Hello,

This PR allows to generate both `dist/gameboy.js` (205.8 kB) and `dist/gameboy.min.js` (61.2 kB) JavaScript files. :)